### PR TITLE
Fix safelist issue

### DIFF
--- a/tailwindcss/safelist.js
+++ b/tailwindcss/safelist.js
@@ -1,5 +1,5 @@
 module.exports = function safelist() {
     return [{
-        pattern: /btn-/
+        pattern: /btn-?/
     }];
 };


### PR DESCRIPTION
Fix an issue with the `btn` safelist regex, wherein the `btn` class was not getting correctly styled in consumers of this package.